### PR TITLE
Refactor folder structure

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+scarb 2.8.5
+starknet-foundry 0.31.0

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -7,7 +7,7 @@ edition = "2023_11"
 # See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest.html
 
 [dependencies]
-starknet = "^2.8.2"
+starknet = "^2.8.3"
 openzeppelin = { git = "https://github.com/OpenZeppelin/cairo-contracts.git", tag = "v0.17.0" }
 
 [dev-dependencies]

--- a/src/base.cairo
+++ b/src/base.cairo
@@ -1,0 +1,1 @@
+pub mod errors;

--- a/src/base/errors.cairo
+++ b/src/base/errors.cairo
@@ -1,0 +1,7 @@
+/// Error messages for the Distributor contract
+pub mod Errors {
+    pub const EMPTY_RECIPIENTS: felt252 = 'Recipients array is empty';
+    pub const ZERO_AMOUNT: felt252 = 'Amount must be greater than 0';
+    pub const INSUFFICIENT_ALLOWANCE: felt252 = 'Insufficient allowance';
+    pub const INVALID_TOKEN: felt252 = 'Invalid token address';
+}

--- a/src/distribute.cairo
+++ b/src/distribute.cairo
@@ -1,36 +1,3 @@
-use starknet::ContractAddress;
-
-/// Interface for the distribution contract
-#[starknet::interface]
-pub trait IDistributor<TContractState> {
-    /// Distributes equal amounts of tokens to multiple recipients
-    fn distribute(
-        ref self: TContractState,
-        amount: u256,
-        recipients: Array<ContractAddress>,
-        token: ContractAddress
-    );
-
-    /// Distributes different amounts of tokens to multiple recipients
-    fn distribute_weighted(
-        ref self: TContractState,
-        amounts: Array<u256>,
-        recipients: Array<ContractAddress>,
-        token: ContractAddress
-    );
-
-    /// Gets the current balance of the contract
-    fn get_balance(self: @TContractState) -> u256;
-}
-
-/// Error messages for the Distributor contract
-pub mod Errors {
-    pub const EMPTY_RECIPIENTS: felt252 = 'Recipients array is empty';
-    pub const ZERO_AMOUNT: felt252 = 'Amount must be greater than 0';
-    pub const INSUFFICIENT_ALLOWANCE: felt252 = 'Insufficient allowance';
-    pub const INVALID_TOKEN: felt252 = 'Invalid token address';
-}
-
 /// Main contract implementation
 #[starknet::contract]
 mod Distributor {
@@ -41,8 +8,11 @@ mod Distributor {
     use starknet::ContractAddress;
     use starknet::{get_caller_address, get_contract_address, ClassHash};
     use core::num::traits::Zero;
-    use super::Errors;
-
+    //  use super::Errors;
+    use fundable::base::errors::Errors::{
+        EMPTY_RECIPIENTS, ZERO_AMOUNT, INSUFFICIENT_ALLOWANCE, INVALID_TOKEN
+    };
+    use fundable::interfaces::IDistributor::IDistributor;
     component!(path: UpgradeableComponent, storage: upgradeable, event: UpgradeableEvent);
     component!(path: OwnableComponent, storage: ownable, event: OwnableEvent);
 
@@ -87,17 +57,24 @@ mod Distributor {
     }
 
     #[abi(embed_v0)]
-    impl DistributorImpl of super::IDistributor<ContractState> {
+    impl DistributorImpl of IDistributor<ContractState> {
         fn distribute(
             ref self: ContractState,
             amount: u256,
             recipients: Array<ContractAddress>,
             token: ContractAddress,
         ) {
+            // QUESTIONS
+            // - how the user approve this contract to spend his token
+            // - checking if the approve the contract to spend his token is done
+            // follow up QUESTION
+            // - does this mean everytime a user want to distribute, we have request for approval
+            // for max amount
+
             // Validate inputs
-            assert(!recipients.is_empty(), Errors::EMPTY_RECIPIENTS);
-            assert(amount > 0, Errors::ZERO_AMOUNT);
-            assert(!token.is_zero(), Errors::INVALID_TOKEN);
+            assert(!recipients.is_empty(), EMPTY_RECIPIENTS);
+            assert(amount > 0, ZERO_AMOUNT);
+            assert(!token.is_zero(), INVALID_TOKEN);
 
             // Create ERC20 dispatcher to interact with the token contract
             let token_dispatcher = IERC20Dispatcher { contract_address: token };
@@ -108,7 +85,7 @@ mod Distributor {
             // Check allowance
             let total_amount = amount * recipients.len().into();
             let allowance = token_dispatcher.allowance(caller, get_contract_address());
-            assert(allowance >= total_amount, Errors::INSUFFICIENT_ALLOWANCE);
+            assert(allowance >= total_amount, INSUFFICIENT_ALLOWANCE);
 
             let recipients_list = recipients.span();
 
@@ -119,16 +96,14 @@ mod Distributor {
             };
 
             // Emit summary event
-            self.emit(
-                Event::Distribution(
-                    Distribution { 
-                        caller,
-                        token, 
-                        amount, 
-                        recipients_count: recipients_list.len() 
-                    }
-                )
-            );
+            self
+                .emit(
+                    Event::Distribution(
+                        Distribution {
+                            caller, token, amount, recipients_count: recipients_list.len()
+                        }
+                    )
+                );
         }
 
         fn distribute_weighted(
@@ -165,26 +140,24 @@ mod Distributor {
                 }
                 let recipient = *recipients.at(i);
                 let amount = *amounts.at(i);
-                
+
                 token_dispatcher.transfer_from(caller, recipient, amount);
-                
+
                 // Emit event for each distribution
                 self.emit(WeightedDistribution { recipient, amount });
-                
+
                 i += 1;
             };
 
             // Add summary event at the end
-            self.emit(
-                Event::Distribution(
-                    Distribution { 
-                        caller,
-                        token, 
-                        amount: total_amount, 
-                        recipients_count: recipients.len() 
-                    }
-                )
-            );
+            self
+                .emit(
+                    Event::Distribution(
+                        Distribution {
+                            caller, token, amount: total_amount, recipients_count: recipients.len()
+                        }
+                    )
+                );
         }
 
         fn get_balance(self: @ContractState) -> u256 {

--- a/src/interfaces.cairo
+++ b/src/interfaces.cairo
@@ -1,0 +1,1 @@
+pub mod IDistributor;

--- a/src/interfaces/IDistributor.cairo
+++ b/src/interfaces/IDistributor.cairo
@@ -1,0 +1,24 @@
+use starknet::ContractAddress;
+
+/// Interface for the distribution contract
+#[starknet::interface]
+pub trait IDistributor<TContractState> {
+    /// Distributes equal amounts of tokens to multiple recipients
+    fn distribute(
+        ref self: TContractState,
+        amount: u256,
+        recipients: Array<ContractAddress>,
+        token: ContractAddress
+    );
+
+    /// Distributes different amounts of tokens to multiple recipients
+    fn distribute_weighted(
+        ref self: TContractState,
+        amounts: Array<u256>,
+        recipients: Array<ContractAddress>,
+        token: ContractAddress
+    );
+
+    /// Gets the current balance of the contract
+    fn get_balance(self: @TContractState) -> u256;
+}

--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -1,2 +1,4 @@
 pub mod distribute;
 pub mod usdc;
+pub mod base;
+pub mod interfaces;

--- a/tests/test_contract.cairo
+++ b/tests/test_contract.cairo
@@ -102,9 +102,9 @@ fn test_weighted_distribution() {
 
     // Create amounts array with different values for each recipient
     let amounts = array![
-        100_u256,  // First recipient gets 100 tokens
-        200_u256,  // Second recipient gets 200 tokens
-        300_u256   // Third recipient gets 300 tokens
+        100_u256, // First recipient gets 100 tokens
+        200_u256, // Second recipient gets 200 tokens
+        300_u256 // Third recipient gets 300 tokens
     ];
 
     let total_amount = 600_u256; // Sum of all amounts
@@ -127,16 +127,13 @@ fn test_weighted_distribution() {
 
     // Assert balances for each recipient
     assert(
-        token.balance_of(contract_address_const::<0x2>()) == 100_u256,
-        'Wrong balance recipient 1'
+        token.balance_of(contract_address_const::<0x2>()) == 100_u256, 'Wrong balance recipient 1'
     );
     assert(
-        token.balance_of(contract_address_const::<0x3>()) == 200_u256,
-        'Wrong balance recipient 2'
+        token.balance_of(contract_address_const::<0x3>()) == 200_u256, 'Wrong balance recipient 2'
     );
     assert(
-        token.balance_of(contract_address_const::<0x4>()) == 300_u256,
-        'Wrong balance recipient 3'
+        token.balance_of(contract_address_const::<0x4>()) == 300_u256, 'Wrong balance recipient 3'
     );
 }
 
@@ -144,12 +141,9 @@ fn test_weighted_distribution() {
 #[should_panic(expected: ('Arrays length mismatch',))]
 fn test_weighted_distribution_mismatched_arrays() {
     let (token_address, sender, distributor) = setup();
-    
+
     // Create unequal length arrays
-    let recipients = array![
-        contract_address_const::<0x2>(),
-        contract_address_const::<0x3>()
-    ];
+    let recipients = array![contract_address_const::<0x2>(), contract_address_const::<0x3>()];
     let amounts = array![100_u256];
 
     start_cheat_caller_address(distributor.contract_address, sender);
@@ -161,7 +155,7 @@ fn test_weighted_distribution_mismatched_arrays() {
 #[should_panic(expected: ('Amount must be greater than 0',))]
 fn test_weighted_distribution_zero_amount() {
     let (token_address, sender, distributor) = setup();
-    
+
     let recipients = array![contract_address_const::<0x2>()];
     let amounts = array![0_u256];
 
@@ -169,7 +163,6 @@ fn test_weighted_distribution_zero_amount() {
     distributor.distribute_weighted(amounts, recipients, token_address);
     stop_cheat_caller_address(distributor.contract_address);
 }
-
 // #[test]
 // fn test_weighted_distribution_events() {
 //     // Setup
@@ -200,16 +193,16 @@ fn test_weighted_distribution_zero_amount() {
 //     spy.assert_emitted(@array![
 //         (
 //             distributor.contract_address,
-//             WeightedDistribution { 
-//                 recipient: contract_address_const::<0x2>(), 
-//                 amount: 100_u256 
+//             WeightedDistribution {
+//                 recipient: contract_address_const::<0x2>(),
+//                 amount: 100_u256
 //             }
 //         ),
 //         (
 //             distributor.contract_address,
-//             WeightedDistribution { 
-//                 recipient: contract_address_const::<0x3>(), 
-//                 amount: 200_u256 
+//             WeightedDistribution {
+//                 recipient: contract_address_const::<0x3>(),
+//                 amount: 200_u256
 //             }
 //         )
 //     ]);
@@ -291,7 +284,7 @@ fn test_weighted_distribution_zero_amount() {
 //     stop_cheat_caller_address(distributor.contract_address);
 
 //     assert(result.is_err(), 'Should fail with zero amount');
-    
+
 //     // Verify no events were emitted
 //     let events = spy.get_events().unwrap();
 //     assert(events.is_empty(), 'Should not emit events');

--- a/tests/test_contract.cairo
+++ b/tests/test_contract.cairo
@@ -4,7 +4,7 @@ use snforge_std::{
     declare, ContractClassTrait, DeclareResultTrait, start_cheat_caller_address,
     stop_cheat_caller_address, start_cheat_caller_address_global, stop_cheat_caller_address_global
 };
-use fundable::distribute::{IDistributorDispatcher, IDistributorDispatcherTrait};
+use fundable::interfaces::IDistributor::{IDistributorDispatcher, IDistributorDispatcherTrait};
 use openzeppelin::token::erc20::interface::{IERC20Dispatcher, IERC20DispatcherTrait};
 
 fn setup() -> (ContractAddress, ContractAddress, IDistributorDispatcher) {


### PR DESCRIPTION
PR Overview

Refactor the contract by moving errors and interfaces into a separate folder. This ensures the contract file remains concise, containing only the storage, essential imports, and interface implementations.