### PR TITLE
Feat: Update Withdrawal Logic To Support Delegate Access

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 scarb 2.9.2
-starknet-foundry 0.35.0
+starknet-foundry 0.38.0

--- a/src/base/errors.cairo
+++ b/src/base/errors.cairo
@@ -34,4 +34,8 @@ pub mod Errors {
 
     /// Thrown when a protocol address is not set
     pub const PROTOCOL_FEE_ADDRESS_NOT_SET: felt252 = 'Error: Zero Protocol address';
+
+    /// Thrown when wrong recipient or delegate
+    pub const WRONG_RECIPIENT_OR_DELEGATE: felt252 = 'WRONG_RECIPIENT_OR_DELEGATE';
 }
+

--- a/src/payment_stream.cairo
+++ b/src/payment_stream.cairo
@@ -12,8 +12,7 @@ mod PaymentStream {
     use fundable::interfaces::IPaymentStream::IPaymentStream;
     use crate::base::errors::Errors::{
         ZERO_AMOUNT, INVALID_TOKEN, UNEXISTING_STREAM, WRONG_RECIPIENT, WRONG_SENDER,
-        INVALID_RECIPIENT, END_BEFORE_START, INSUFFICIENT_ALLOWANCE,
-        WRONG_RECIPIENT_OR_DELEGATE
+        INVALID_RECIPIENT, END_BEFORE_START, INSUFFICIENT_ALLOWANCE, WRONG_RECIPIENT_OR_DELEGATE,
     };
     use openzeppelin::access::accesscontrol::AccessControlComponent;
     use openzeppelin::introspection::src5::SRC5Component;
@@ -197,7 +196,6 @@ mod PaymentStream {
         fn collect_protocol_fee(
             self: @ContractState, sender: ContractAddress, token: ContractAddress, amount: u256,
         ) {
-
             let fee_collector: ContractAddress = self.fee_collector.read();
             assert(fee_collector.is_non_zero(), INVALID_RECIPIENT);
             IERC20Dispatcher { contract_address: token }
@@ -280,7 +278,6 @@ mod PaymentStream {
         fn withdraw(
             ref self: ContractState, stream_id: u256, amount: u256, to: ContractAddress,
         ) -> (u128, u128) {
-
             self.assert_is_recipient_or_delegate(stream_id);
             assert(amount > 0, ZERO_AMOUNT);
             assert(to.is_non_zero(), INVALID_RECIPIENT);

--- a/tests/test_payment_stream.cairo
+++ b/tests/test_payment_stream.cairo
@@ -224,7 +224,8 @@ fn test_withdraw_by_delegate() {
 
     // Sender creates a stream.
     start_cheat_caller_address(payment_stream.contract_address, sender);
-    let stream_id = payment_stream.create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address);
+    let stream_id = payment_stream
+        .create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address);
     // Sender assigns a delegate.
     payment_stream.delegate_stream(stream_id, delegate);
     stop_cheat_caller_address(payment_stream.contract_address);
@@ -263,7 +264,8 @@ fn test_withdraw_by_unauthorized() {
 
     // Sender creates a stream.
     start_cheat_caller_address(payment_stream.contract_address, sender);
-    let stream_id = payment_stream.create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address);
+    let stream_id = payment_stream
+        .create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address);
     stop_cheat_caller_address(payment_stream.contract_address);
 
     // Unauthorized account attempts withdrawal.

--- a/tests/test_payment_stream.cairo
+++ b/tests/test_payment_stream.cairo
@@ -136,6 +136,7 @@ fn test_withdraw() {
     let start_time = 100_u64;
     let end_time = 200_u64;
     let cancelable = true;
+    let delegate = contract_address_const::<'delegate'>();
 
     let new_fee_collector: ContractAddress = contract_address_const::<'new_fee_collector'>();
     let protocol_owner: ContractAddress = contract_address_const::<'protocol_owner'>();
@@ -146,26 +147,25 @@ fn test_withdraw() {
     start_cheat_caller_address(payment_stream.contract_address, sender);
     let stream_id = payment_stream
         .create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address);
-    stop_cheat_caller_address(payment_stream.contract_address);
-
-    start_cheat_caller_address(payment_stream.contract_address, protocol_owner);
-    payment_stream.update_percentage_protocol_fee(300);
+    // Sender assigns a delegate.
+    payment_stream.delegate_stream(stream_id, delegate);
     stop_cheat_caller_address(payment_stream.contract_address);
 
     let token_dispatcher = IERC20Dispatcher { contract_address: token_address };
     let sender_initial_balance = token_dispatcher.balance_of(sender);
     println!("Initial balance of sender: {}", sender_initial_balance);
 
-    start_cheat_caller_address(token_address, sender);
+    // Simulate delegate's approval:
+    start_cheat_caller_address(token_address, delegate);
     token_dispatcher.approve(payment_stream.contract_address, total_amount);
     stop_cheat_caller_address(token_address);
 
-    let allowance = token_dispatcher.allowance(sender, payment_stream.contract_address);
+    let allowance = token_dispatcher.allowance(delegate, payment_stream.contract_address);
     assert(allowance >= total_amount, 'Allowance not set correctly');
     println!("Allowance for withdrawal: {}", allowance);
 
-    start_cheat_caller_address(payment_stream.contract_address, sender);
-    let (net_amount, fee) = payment_stream.withdraw(stream_id, 1000, recipient);
+    start_cheat_caller_address(payment_stream.contract_address, delegate);
+    let (_, fee) = payment_stream.withdraw(stream_id, 1000, recipient);
     stop_cheat_caller_address(payment_stream.contract_address);
 
     // let recipient_balance = token_dispatcher.balance_of(recipient);
@@ -207,3 +207,68 @@ fn test_successful_stream_cancellation() {
 
     assert(get_let == false, 'Cancelation failed');
 }
+
+#[test]
+fn test_withdraw_by_delegate() {
+    // Setup: deploy contracts and define test addresses.
+    let (token_address, sender, payment_stream) = setup();
+    let recipient = contract_address_const::<'recipient'>();
+    let delegate = contract_address_const::<'delegate'>();
+    let total_amount = 10000_u256;
+    let start_time = 100_u64;
+    let end_time = 200_u64;
+    let cancelable = true;
+
+    let protocol_owner: ContractAddress = contract_address_const::<'protocol_owner'>();
+    let new_fee_collector: ContractAddress = contract_address_const::<'new_fee_collector'>();
+
+    // Sender creates a stream.
+    start_cheat_caller_address(payment_stream.contract_address, sender);
+    let stream_id = payment_stream.create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address);
+    // Sender assigns a delegate.
+    payment_stream.delegate_stream(stream_id, delegate);
+    stop_cheat_caller_address(payment_stream.contract_address);
+
+    start_cheat_caller_address(payment_stream.contract_address, protocol_owner);
+    payment_stream.update_fee_collector(new_fee_collector);
+    stop_cheat_caller_address(payment_stream.contract_address);
+
+    // Simulate delegate's approval:
+    let token_dispatcher = IERC20Dispatcher { contract_address: token_address };
+    start_cheat_caller_address(token_address, delegate);
+    token_dispatcher.approve(payment_stream.contract_address, 5000_u256);
+    stop_cheat_caller_address(token_address);
+
+    // Delegate performs withdrawal.
+    start_cheat_caller_address(payment_stream.contract_address, delegate);
+    let (_, fee) = payment_stream.withdraw(stream_id, 5000_u256, recipient);
+    stop_cheat_caller_address(payment_stream.contract_address);
+
+    let fee_collector = payment_stream.get_fee_collector();
+    let fee_collector_balance = token_dispatcher.balance_of(fee_collector);
+    assert(fee_collector_balance == fee.into(), 'incorrect fee received');
+}
+
+#[test]
+#[should_panic(expected: 'WRONG_RECIPIENT_OR_DELEGATE')]
+fn test_withdraw_by_unauthorized() {
+    // Setup: deploy contracts and define test addresses.
+    let (token_address, sender, payment_stream) = setup();
+    let recipient = contract_address_const::<'recipient'>();
+    let unauthorized = contract_address_const::<'unauthorized'>();
+    let total_amount = 10000_u256;
+    let start_time = 100_u64;
+    let end_time = 200_u64;
+    let cancelable = true;
+
+    // Sender creates a stream.
+    start_cheat_caller_address(payment_stream.contract_address, sender);
+    let stream_id = payment_stream.create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address);
+    stop_cheat_caller_address(payment_stream.contract_address);
+
+    // Unauthorized account attempts withdrawal.
+    start_cheat_caller_address(payment_stream.contract_address, unauthorized);
+    payment_stream.withdraw(stream_id, 5000_u256, recipient);
+    stop_cheat_caller_address(payment_stream.contract_address);
+}
+


### PR DESCRIPTION
# Update Withdrawal Logic for Delegation

## Description

This PR updates the withdrawal logic to support delegate access. The following changes have been made:

### Changes Made
1. **Withdrawal Functions**:
   - Updated the `withdraw` and `withdraw_max` functions to include validation for delegate access.

2. **Delegate Validation**:
   - Added a helper function `assert_is_recipient_or_delegate` to validate if the caller is either the recipient or a delegate of the stream.

3. **Error Constants**:
   - Added a new error constant `WRONG_RECIPIENT_OR_DELEGATE` to handle cases where the caller is neither the recipient nor the delegate.

4. **Tests**:
   - Added tests to ensure that only the recipient or a valid delegate can perform withdrawals.
   - Included negative tests to confirm that unauthorized accounts cannot withdraw.

### Checklist
- [x] Update `withdraw` function.
- [x] Update `withdraw_max` function.
- [x] Add `assert_is_recipient_or_delegate` function.
- [x] Update error constants.
- [x] Add tests for delegate withdrawal.
- [x] Add tests for unauthorized withdrawal attempts.

## Related Issues
- Closes #34