### PR TITLE
Enhance protocol fee management

### DIFF
--- a/src/interfaces/IPaymentStream.cairo
+++ b/src/interfaces/IPaymentStream.cairo
@@ -173,12 +173,12 @@ pub trait IPaymentStream<TContractState> {
     /// @notice Gets the protocol fee of the token
     /// @param token The ContractAddress of the token
     /// @return u256 The fee of the token
-    fn protocol_fee(self: @TContractState, token: ContractAddress) -> u256;
+    fn get_protocol_fee(self: @TContractState, token: ContractAddress) -> u256;
 
     /// @notice Get the protocol revenue / accumulated fees of the token
     /// @param token The ContractAddress of the token
-    /// @@return u256 The accumulated fees of the token
-    fn protocol_revenue(self: @TContractState, token: ContractAddress) -> u256;
+    /// @return u256 The accumulated fees of the token
+    fn get_protocol_revenue(self: @TContractState, token: ContractAddress) -> u256;
 
     /// @notice Allow authorized addresses to collect revenue for a specific token.
     /// @param token The ContractAddress of the token

--- a/src/interfaces/IPaymentStream.cairo
+++ b/src/interfaces/IPaymentStream.cairo
@@ -169,4 +169,26 @@ pub trait IPaymentStream<TContractState> {
     fn update_stream_rate(
         ref self: TContractState, stream_id: u256, new_rate_per_second: UFixedPoint123x128,
     );
+
+    /// @notice Gets the protocol fee of the token
+    /// @param token The ContractAddress of the token
+    /// @return u256 The fee of the token
+    fn protocol_fee(self: @TContractState, token: ContractAddress) -> u256;
+
+    /// @notice Get the protocol revenue / accumulated fees of the token
+    /// @param token The ContractAddress of the token
+    /// @@return u256 The accumulated fees of the token
+    fn protocol_revenue(self: @TContractState, token: ContractAddress) -> u256;
+
+    /// @notice Allow authorized addresses to collect revenue for a specific token.
+    /// @param token The ContractAddress of the token
+    /// @param to The ContractAddress that will receive the revenue
+    fn collect_protocol_revenue(
+        ref self: TContractState, token: ContractAddress, to: ContractAddress,
+    );
+
+    /// @notice Set the protocol fee of the token
+    /// @param token The ContractAddress of the token
+    /// @param new_protocol_fee The new protocol fee of the token
+    fn set_protocol_fee(ref self: TContractState, token: ContractAddress, new_protocol_fee: u256);
 }

--- a/src/payment_stream.cairo
+++ b/src/payment_stream.cairo
@@ -685,19 +685,19 @@ mod PaymentStream {
                     ),
                 );
         }
-        fn protocol_fee(self: @ContractState, token: ContractAddress) -> u256 {
+        fn get_protocol_fee(self: @ContractState, token: ContractAddress) -> u256 {
             self.protocol_fees.read(token)
         }
-        fn protocol_revenue(self: @ContractState, token: ContractAddress) -> u256 {
+        fn get_protocol_revenue(self: @ContractState, token: ContractAddress) -> u256 {
             self.protocol_revenue.read(token)
         }
         fn collect_protocol_revenue(
             ref self: ContractState, token: ContractAddress, to: ContractAddress,
         ) {
             self.accesscontrol.assert_only_role(PROTOCOL_OWNER_ROLE);
-            protocol_revenue = self.protocol_revenue.read(token);
+            let protocol_revenue = self.protocol_revenue.read(token);
             self.protocol_revenue.write(token, 0_u256);
-            token_dispatcher = IERC20Dispatcher { contract_address: token };
+            let token_dispatcher = IERC20Dispatcher { contract_address: token };
             token_dispatcher.transfer(to, protocol_revenue);
             self
                 .emit(

--- a/tests/test_payment_stream.cairo
+++ b/tests/test_payment_stream.cairo
@@ -803,3 +803,44 @@ fn test_decimal_boundary_conditions() {
         );
     assert(ps0.get_token_decimals(stream_id0) == 0, 'Min decimals failed');
 }
+
+
+#[test]
+fn test_set_protocol_fee_successful(){
+    let protocol_owner: ContractAddress = contract_address_const::<'protocol_owner'>();
+    let fee: u256 = 500; // 5%
+    let (token_address, sender, payment_stream) = setup();
+    // Set fee
+    start_cheat_caller_address(payment_stream.contract_address, protocol_owner);
+    payment_stream.set_protocol_fee(token_address, fee);
+    stop_cheat_caller_address(payment_stream.contract_address);
+
+    assert(payment_stream.get_protocol_fee(token_address) == fee, 'invalid fee')
+
+}
+
+#[test]
+#[should_panic]
+fn test_set_protocol_fee_fail_if_more_than_max_fee(){
+    let protocol_owner: ContractAddress = contract_address_const::<'protocol_owner'>();
+    let fee: u256 = 10000; // 100%. MAX_FEE = 50%
+    let (token_address, sender, payment_stream) = setup();
+    // Set fee
+    start_cheat_caller_address(payment_stream.contract_address, protocol_owner);
+    payment_stream.set_protocol_fee(token_address, fee); // should panic
+    stop_cheat_caller_address(payment_stream.contract_address);
+
+}
+
+#[test]
+#[should_panic]
+fn test_set_protocol_fee_fail_if_invalid_caller(){
+    let random_caller: ContractAddress = contract_address_const::<'random'>();
+    let fee: u256 = 500; // 5%
+    let (token_address, sender, payment_stream) = setup();
+    // Set fee
+    start_cheat_caller_address(payment_stream.contract_address, random_caller);
+    payment_stream.set_protocol_fee(token_address, fee); // should panic
+    stop_cheat_caller_address(payment_stream.contract_address);
+
+}


### PR DESCRIPTION
Closes #59 

## Summary
This PR enhances the protocol fee system by implementing token-specific fees and revenue collection mechanisms. Instead of using a single global fee, the protocol can now configure different fee percentages for each token,.

## Changes
- Added storage for tracking fees and revenue by token address
- Implemented token-specific protocol fee functionality
- Added revenue collection mechanism with appropriate access control
- Set maximum fee limits to protect users
- Added relevant events for fee changes and revenue collection

## Implementation Details
- Modified the storage structure to track fees and accumulated revenue per token
- Added new functions to the `IPaymentStream` interface:
  - `protocol_fee`: View function to check current fee for a specific token
  - `protocol_revenue`: View function to check accumulated revenue for a token
  - `collect_protocol_revenue`: Allows authorized addresses to collect accumulated fees
  - `set_protocol_fee`: Allows protocol owners to set token-specific fees
- Added `MAX_FEE` constant to cap the maximum fee percentage (50% or 5000 basis points)
- Implemented access control using the `PROTOCOL_OWNER_ROLE` for privileged operations
- Added events for fee changes and revenue collection operations

## Test 
- Added test cases for setting protocol fee
    - Proper error handling for invalid caller
    - Proper error handling for out of bound fee.
    - Successful execution of set_protocol_fee function.
  