### PR TITLE
Add NFT Transferability Flag to Streams #58

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,8 @@ let stream = payment_stream.create_stream(
     total_amount,
     start_time,
     end_time,
-    token
+    token,
+    transferable
 );
 
 // Withdraw from stream
@@ -178,7 +179,8 @@ Event::StreamCreated(
         sender,         // Stream creator address
         recipient,      // Payment recipient address
         total_amount,   // Total tokens to be streamed
-        token          // ERC20 token address
+        token,          // ERC20 token address
+        transferable    // NFT Transferability Flag
     }
 )
 ```

--- a/src/base/errors.cairo
+++ b/src/base/errors.cairo
@@ -16,6 +16,9 @@ pub mod Errors {
     /// Thrown when attempting to create a stream or make a payment with zero tokens
     pub const ZERO_AMOUNT: felt252 = 'Error: Amount must be > 0.';
 
+    /// Thrown when a stream is not transferable.
+    pub const NON_TRANSFERABLE_STREAM: felt252 = 'Error: Non-transferrable stream';
+
     /// Thrown when the contract does not have sufficient allowance to transfer tokens on behalf of
     /// the sender
     pub const INSUFFICIENT_ALLOWANCE: felt252 = 'Error: Insufficient allowance.';

--- a/src/base/types.cairo
+++ b/src/base/types.cairo
@@ -5,6 +5,7 @@ use starknet::ContractAddress;
 #[derive(Drop, Serde, starknet::Store)]
 pub struct Stream {
     pub sender: ContractAddress,
+    pub recipient: ContractAddress,
     pub total_amount: u256,
     pub withdrawn_amount: u256,
     pub start_time: u64,

--- a/src/base/types.cairo
+++ b/src/base/types.cairo
@@ -16,6 +16,7 @@ pub struct Stream {
     pub status: StreamStatus,
     pub rate_per_second: UFixedPoint123x128,
     pub last_update_time: u64,
+    pub transferable: bool,
 }
 
 #[derive(Drop, starknet::Event)]

--- a/src/events.cairo
+++ b/src/events.cairo
@@ -73,6 +73,7 @@ fn create_stream(
     end_time: u64,
     cancelable: bool,
     token: ContractAddress,
+    transferable: bool,
 ) -> u256 {
     // ... stream creation logic ...
 

--- a/src/interfaces/IPaymentStream.cairo
+++ b/src/interfaces/IPaymentStream.cairo
@@ -23,7 +23,7 @@ pub trait IPaymentStream<TContractState> {
         end_time: u64,
         cancelable: bool,
         token: ContractAddress,
-        transferable: bool
+        transferable: bool,
     ) -> u256;
 
     /// @notice Withdraws the provided amount minus the protocol fee to the provided address

--- a/src/interfaces/IPaymentStream.cairo
+++ b/src/interfaces/IPaymentStream.cairo
@@ -13,6 +13,7 @@ pub trait IPaymentStream<TContractState> {
     /// @param end_time The timestamp when the stream ends
     /// @param cancelable Boolean indicating if the stream can be canceled
     /// @param token The contract address of the ERC-20 token to be streamed
+    /// @param transferable Boolean indicating if the stream can be transferred
     /// @return The ID of the newly created stream
     fn create_stream(
         ref self: TContractState,
@@ -22,6 +23,7 @@ pub trait IPaymentStream<TContractState> {
         end_time: u64,
         cancelable: bool,
         token: ContractAddress,
+        transferable: bool
     ) -> u256;
 
     /// @notice Withdraws the provided amount minus the protocol fee to the provided address
@@ -150,7 +152,7 @@ pub trait IPaymentStream<TContractState> {
     /// @notice Delegate a contract address to a stream
     /// @param stream_id The stream ID for the query
     /// @param delegate The address to delegate a stream to
-    /// @return Boolean indicating if the stream delegation is successsful
+    /// @return Boolean indicating if the stream delegation is successful
     fn delegate_stream(
         ref self: TContractState, stream_id: u256, delegate: ContractAddress,
     ) -> bool;
@@ -169,4 +171,19 @@ pub trait IPaymentStream<TContractState> {
     fn update_stream_rate(
         ref self: TContractState, stream_id: u256, new_rate_per_second: UFixedPoint123x128,
     );
+
+    /// @notice Transfers the stream to a new recipient
+    /// @param stream_id The ID of the stream to transfer
+    /// @param new_recipient The address of the new recipient
+    fn transfer_stream(ref self: TContractState, stream_id: u256, new_recipient: ContractAddress);
+
+    /// @notice Sets the transferability of the stream
+    /// @param stream_id The ID of the stream to update
+    /// @param transferable Boolean indicating if the stream can be transferred
+    fn set_transferability(ref self: TContractState, stream_id: u256, transferable: bool);
+
+    /// @notice Checks if the stream is transferable
+    /// @param stream_id The ID of the stream to check
+    /// @return Boolean indicating if the stream is transferable
+    fn is_transferable(self: @TContractState, stream_id: u256) -> bool;
 }

--- a/src/payment_stream.cairo
+++ b/src/payment_stream.cairo
@@ -351,6 +351,7 @@ mod PaymentStream {
                 token_decimals,
                 total_amount,
                 balance: 0,
+                recipient,
                 start_time,
                 end_time,
                 withdrawn_amount: 0,
@@ -886,6 +887,7 @@ mod PaymentStream {
             let new_stream = Stream {
                 rate_per_second: new_rate_per_second,
                 sender: stream.sender,
+                recipient: stream.recipient,
                 token: stream.token,
                 token_decimals: stream.token_decimals,
                 total_amount: stream.total_amount,

--- a/src/payment_stream.cairo
+++ b/src/payment_stream.cairo
@@ -335,9 +335,8 @@ mod PaymentStream {
             // Verify stream exists
             self.assert_stream_exists(stream_id);
             
-            // Verify the caller is the stream recipient
-            self.assert_is_recipient(stream_id);
-            self.assert_is_recipient(stream_id);
+            // Verify the caller is the stream owner (sender)
+            self.assert_is_sender(stream_id);
             
             // Verify the stream is transferable
             self.assert_is_transferable(stream_id);
@@ -366,7 +365,7 @@ mod PaymentStream {
             // Verify stream exists
             self.assert_stream_exists(stream_id);
             
-            // Verify the caller is the stream sender (creator)
+            // Verify the caller is the stream owner (sender)
             self.assert_is_sender(stream_id);
             
             // Get current stream details
@@ -381,7 +380,6 @@ mod PaymentStream {
             
             // Emit event about transferability change
             self.emit(StreamTransferabilitySet { stream_id, transferable });
-            
         }
 
         fn is_transferable(self: @ContractState, stream_id: u256) -> bool {

--- a/src/payment_stream.cairo
+++ b/src/payment_stream.cairo
@@ -20,8 +20,8 @@ mod PaymentStream {
     };
     use crate::base::errors::Errors::{
         DECIMALS_TOO_HIGH, END_BEFORE_START, INSUFFICIENT_ALLOWANCE, INVALID_RECIPIENT,
-        INVALID_TOKEN, TOO_SHORT_DURATION, UNEXISTING_STREAM, WRONG_RECIPIENT,
-        WRONG_RECIPIENT_OR_DELEGATE, WRONG_SENDER, ZERO_AMOUNT, NON_TRANSFERABLE_STREAM,
+        INVALID_TOKEN, NON_TRANSFERABLE_STREAM, TOO_SHORT_DURATION, UNEXISTING_STREAM,
+        WRONG_RECIPIENT, WRONG_RECIPIENT_OR_DELEGATE, WRONG_SENDER, ZERO_AMOUNT,
     };
     use crate::base::types::{ProtocolMetrics, Stream, StreamMetrics, StreamStatus};
 
@@ -257,7 +257,7 @@ mod PaymentStream {
             end_time: u64,
             cancelable: bool,
             token: ContractAddress,
-            transferable: bool
+            transferable: bool,
         ) -> u256 {
             // Validate inputs
             assert(!recipient.is_zero(), INVALID_RECIPIENT);
@@ -314,10 +314,10 @@ mod PaymentStream {
                 .emit(
                     Event::StreamCreated(
                         StreamCreated {
-                            stream_id, 
-                            sender: get_caller_address(), 
-                            recipient, 
-                            total_amount, 
+                            stream_id,
+                            sender: get_caller_address(),
+                            recipient,
+                            total_amount,
                             token,
                             transferable,
                         },
@@ -328,28 +328,26 @@ mod PaymentStream {
         }
 
         fn transfer_stream(
-            ref self: ContractState,
-            stream_id: u256,
-            new_recipient: ContractAddress,
+            ref self: ContractState, stream_id: u256, new_recipient: ContractAddress,
         ) {
             // Verify stream exists
             self.assert_stream_exists(stream_id);
-            
+
             // Verify the caller is the stream owner (sender)
             self.assert_is_sender(stream_id);
-            
+
             // Verify the stream is transferable
             self.assert_is_transferable(stream_id);
-            
+
             // Verify valid new recipient
             assert(new_recipient.is_non_zero(), INVALID_RECIPIENT);
-            
+
             // Get current stream details
             let mut stream = self.streams.read(stream_id);
-            
+
             // Update recipient
             stream.recipient = new_recipient;
-            
+
             // Save updated stream
             self.streams.write(stream_id, stream);
 
@@ -357,27 +355,23 @@ mod PaymentStream {
             self.emit(StreamTransferred { stream_id, new_recipient });
         }
 
-        fn set_transferability(
-            ref self: ContractState,
-            stream_id: u256,
-            transferable: bool,
-        ) {
+        fn set_transferability(ref self: ContractState, stream_id: u256, transferable: bool) {
             // Verify stream exists
             self.assert_stream_exists(stream_id);
-            
+
             // Verify the caller is the stream owner (sender)
             self.assert_is_sender(stream_id);
-            
+
             // Get current stream details
             let mut stream = self.streams.read(stream_id);
-            
+
             // Update transferability if it's different from current setting
             if stream.transferable != transferable {
                 stream.transferable = transferable;
             }
             // Save updated stream
             self.streams.write(stream_id, stream);
-            
+
             // Emit event about transferability change
             self.emit(StreamTransferabilitySet { stream_id, transferable });
         }
@@ -385,7 +379,7 @@ mod PaymentStream {
         fn is_transferable(self: @ContractState, stream_id: u256) -> bool {
             // Get stream details
             let stream = self.streams.read(stream_id);
-            
+
             // Return transferability status
             stream.transferable
         }

--- a/tests/test_payment_stream.cairo
+++ b/tests/test_payment_stream.cairo
@@ -88,7 +88,9 @@ fn test_successful_create_stream() {
     let cancelable = true;
     let transferable = true; // Corrected spelling from tranferable to transferable
     let stream_id = payment_stream
-        .create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address, transferable);
+        .create_stream(
+            recipient, total_amount, start_time, end_time, cancelable, token_address, transferable,
+        );
     println!("Stream ID: {}", stream_id);
 
     // This is the first Stream Created, so it will be 0.
@@ -107,7 +109,9 @@ fn test_invalid_end_time() {
     let transferable = true; // Added transferable boolean
 
     payment_stream
-        .create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address, transferable);
+        .create_stream(
+            recipient, total_amount, start_time, end_time, cancelable, token_address, transferable,
+        );
 }
 
 #[test]
@@ -122,7 +126,9 @@ fn test_zero_recipient_address() {
     let transferable = true; // Added transferable boolean
 
     payment_stream
-        .create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address, transferable);
+        .create_stream(
+            recipient, total_amount, start_time, end_time, cancelable, token_address, transferable,
+        );
 }
 
 #[test]
@@ -144,7 +150,7 @@ fn test_zero_token_address() {
             end_time,
             cancelable,
             contract_address_const::<0x0>(),
-            transferable, 
+            transferable,
         );
 }
 
@@ -157,10 +163,12 @@ fn test_zero_total_amount() {
     let start_time = 100_u64;
     let end_time = 200_u64;
     let cancelable = true;
-    let transferable = true; 
+    let transferable = true;
 
     payment_stream
-        .create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address, transferable);
+        .create_stream(
+            recipient, total_amount, start_time, end_time, cancelable, token_address, transferable,
+        );
 }
 
 #[test]
@@ -171,10 +179,12 @@ fn test_successful_create_stream_and_return_correct_rate_per_second() {
     let start_time = 0_u64;
     let end_time = 10_u64;
     let cancelable = false;
-    let transferable = true; 
+    let transferable = true;
 
     let stream_id = payment_stream
-        .create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address, transferable);
+        .create_stream(
+            recipient, total_amount, start_time, end_time, cancelable, token_address, transferable,
+        );
     let stream = payment_stream.get_stream(stream_id);
     let rate_per_second: UFixedPoint123x128 = 10_u256.into();
     assert!(stream.rate_per_second == rate_per_second, "Stream rate per second is invalid");
@@ -188,10 +198,12 @@ fn test_successful_create_stream_and_return_wrong_rate_per_second() {
     let start_time = 0_u64;
     let end_time = 10_u64;
     let cancelable = false;
-    let transferable = true; 
+    let transferable = true;
 
     let stream_id = payment_stream
-        .create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address, transferable);
+        .create_stream(
+            recipient, total_amount, start_time, end_time, cancelable, token_address, transferable,
+        );
     let stream = payment_stream.get_stream(stream_id);
     let rate_per_second: UFixedPoint123x128 = 1_u256.into();
     assert!(stream.rate_per_second == rate_per_second, "Stream rate per second is invalid");
@@ -206,10 +218,12 @@ fn test_update_stream_with_zero_rate_per_second() {
     let start_time = 0_u64;
     let end_time = 10_u64;
     let cancelable = false;
-    let transferable = true; 
+    let transferable = true;
 
     let stream_id = payment_stream
-        .create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address, transferable);
+        .create_stream(
+            recipient, total_amount, start_time, end_time, cancelable, token_address, transferable,
+        );
     let rate_per_second: UFixedPoint123x128 = 0_u256.into();
     payment_stream.update_stream_rate(stream_id, rate_per_second);
     stop_cheat_caller_address(payment_stream.contract_address);
@@ -225,10 +239,12 @@ fn test_only_creator_can_update_stream() {
     let start_time = 0_u64;
     let end_time = 10_u64;
     let cancelable = false;
-    let transferable = true; 
+    let transferable = true;
 
     let stream_id = payment_stream
-        .create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address, transferable);
+        .create_stream(
+            recipient, total_amount, start_time, end_time, cancelable, token_address, transferable,
+        );
     payment_stream.delegate_stream(stream_id, contract_address_const::<0x1>());
     stop_cheat_caller_address(payment_stream.contract_address);
     let rate_per_second: UFixedPoint123x128 = 1_u256.into();
@@ -279,7 +295,9 @@ fn test_withdraw() {
 
     start_cheat_caller_address(payment_stream.contract_address, sender);
     let stream_id = payment_stream
-        .create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address, true); 
+        .create_stream(
+            recipient, total_amount, start_time, end_time, cancelable, token_address, true,
+        );
     payment_stream.delegate_stream(stream_id, delegate);
     stop_cheat_caller_address(payment_stream.contract_address);
 
@@ -327,7 +345,9 @@ fn test_successful_stream_cancellation() {
     stop_cheat_caller_address(payment_stream.contract_address);
 
     let stream_id = payment_stream
-        .create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address, true); 
+        .create_stream(
+            recipient, total_amount, start_time, end_time, cancelable, token_address, true,
+        );
     println!("Stream ID: {}", stream_id);
 
     // This is the first Stream Created, so it will be 0.
@@ -356,7 +376,9 @@ fn test_withdraw_by_delegate() {
     // Sender creates a stream.
     start_cheat_caller_address(payment_stream.contract_address, sender);
     let stream_id = payment_stream
-        .create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address, true); 
+        .create_stream(
+            recipient, total_amount, start_time, end_time, cancelable, token_address, true,
+        );
     payment_stream.delegate_stream(stream_id, delegate);
     stop_cheat_caller_address(payment_stream.contract_address);
 
@@ -395,7 +417,9 @@ fn test_withdraw_by_unauthorized() {
     // Sender creates a stream.
     start_cheat_caller_address(payment_stream.contract_address, sender);
     let stream_id = payment_stream
-        .create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address, true); // Added transferable boolean
+        .create_stream(
+            recipient, total_amount, start_time, end_time, cancelable, token_address, true,
+        ); // Added transferable boolean
     stop_cheat_caller_address(payment_stream.contract_address);
 
     // Unauthorized account attempts withdrawal.
@@ -418,7 +442,9 @@ fn test_unauthorized_cancel() {
     // Create a stream as the sender - this will automatically assign STREAM_ADMIN_ROLE
     start_cheat_caller_address(payment_stream.contract_address, sender);
     let stream_id = payment_stream
-        .create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address, true); // Added transferable boolean
+        .create_stream(
+            recipient, total_amount, start_time, end_time, cancelable, token_address, true,
+        ); // Added transferable boolean
 
     // Verify that the sender has the STREAM_ADMIN_ROLE after creating the stream
     let has_role = access_control.has_role(STREAM_ADMIN_ROLE, sender);
@@ -449,7 +475,9 @@ fn test_pause_stream() {
     // Create a stream
     start_cheat_caller_address(payment_stream.contract_address, sender);
     let stream_id = payment_stream
-        .create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address, true); // Added transferable boolean
+        .create_stream(
+            recipient, total_amount, start_time, end_time, cancelable, token_address, true,
+        ); // Added transferable boolean
 
     // Pause the stream
     payment_stream.pause(stream_id);
@@ -472,7 +500,9 @@ fn test_restart_stream() {
     // Create a stream
     start_cheat_caller_address(payment_stream.contract_address, sender);
     let stream_id = payment_stream
-        .create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address, true); // Added transferable boolean
+        .create_stream(
+            recipient, total_amount, start_time, end_time, cancelable, token_address, true,
+        ); // Added transferable boolean
 
     // Pause the stream first
     payment_stream.pause(stream_id);
@@ -504,7 +534,9 @@ fn test_void_stream() {
     // Create a stream
     start_cheat_caller_address(payment_stream.contract_address, sender);
     let stream_id = payment_stream
-        .create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address, true); // Added transferable boolean
+        .create_stream(
+            recipient, total_amount, start_time, end_time, cancelable, token_address, true,
+        ); // Added transferable boolean
 
     // Void the stream
     payment_stream.void(stream_id);
@@ -529,7 +561,9 @@ fn test_delegate_assignment_and_verification() {
     // Create stream
     start_cheat_caller_address(payment_stream.contract_address, sender);
     let stream_id = payment_stream
-        .create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address, true); // Added transferable boolean
+        .create_stream(
+            recipient, total_amount, start_time, end_time, cancelable, token_address, true,
+        ); // Added transferable boolean
 
     // Assign delegate
     let delegation_success = payment_stream.delegate_stream(stream_id, delegate);
@@ -556,7 +590,9 @@ fn test_multiple_delegations() {
     // Create stream
     start_cheat_caller_address(payment_stream.contract_address, sender);
     let stream_id = payment_stream
-        .create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address, true); // Added transferable boolean
+        .create_stream(
+            recipient, total_amount, start_time, end_time, cancelable, token_address, true,
+        ); // Added transferable boolean
 
     // Assign first delegate
     payment_stream.delegate_stream(stream_id, delegate1);
@@ -584,7 +620,9 @@ fn test_delegation_revocation() {
     // Create stream and assign delegate
     start_cheat_caller_address(payment_stream.contract_address, sender);
     let stream_id = payment_stream
-        .create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address, true); // Added transferable boolean
+        .create_stream(
+            recipient, total_amount, start_time, end_time, cancelable, token_address, true,
+        ); // Added transferable boolean
     payment_stream.delegate_stream(stream_id, delegate);
 
     // Verify delegate is assigned
@@ -617,7 +655,9 @@ fn test_unauthorized_delegation() {
     // Create stream as sender
     start_cheat_caller_address(payment_stream.contract_address, sender);
     let stream_id = payment_stream
-        .create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address, true); // Added transferable boolean
+        .create_stream(
+            recipient, total_amount, start_time, end_time, cancelable, token_address, true,
+        ); // Added transferable boolean
     stop_cheat_caller_address(payment_stream.contract_address);
 
     // Try to delegate from unauthorized address
@@ -640,7 +680,9 @@ fn test_revoke_nonexistent_delegation() {
     // Create stream
     start_cheat_caller_address(payment_stream.contract_address, sender);
     let stream_id = payment_stream
-        .create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address, true); // Added transferable boolean
+        .create_stream(
+            recipient, total_amount, start_time, end_time, cancelable, token_address, true,
+        ); // Added transferable boolean
 
     // Try to revoke non-existent delegation
     payment_stream.revoke_delegation(stream_id);
@@ -669,7 +711,9 @@ fn test_delegate_withdrawal_after_revocation() {
 
     start_cheat_caller_address(payment_stream.contract_address, sender);
     let stream_id = payment_stream
-        .create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address, true); // Added transferable boolean
+        .create_stream(
+            recipient, total_amount, start_time, end_time, cancelable, token_address, true,
+        ); // Added transferable boolean
 
     // Assign and then revoke delegate
     payment_stream.delegate_stream(stream_id, delegate);
@@ -703,7 +747,9 @@ fn test_delegate_to_zero_address() {
     // Create stream
     start_cheat_caller_address(payment_stream.contract_address, sender);
     let stream_id = payment_stream
-        .create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address, true); // Added transferable boolean
+        .create_stream(
+            recipient, total_amount, start_time, end_time, cancelable, token_address, true,
+        ); // Added transferable boolean
 
     // Try to delegate to zero address
     payment_stream.delegate_stream(stream_id, contract_address_const::<0x0>());
@@ -716,15 +762,7 @@ fn test_six_decimals_store() {
     let (token_address, sender, payment_stream) = setup_custom_decimals(test_decimals);
 
     let stream_id = payment_stream
-        .create_stream(
-            sender, 
-            1000000_u256, 
-            100_u64, 
-            200_u64, 
-            true, 
-            token_address, 
-            true 
-        );
+        .create_stream(sender, 1000000_u256, 100_u64, 200_u64, true, token_address, true);
 
     let stored_decimals = payment_stream.get_token_decimals(stream_id);
     assert(stored_decimals == test_decimals, 'Decimals not stored correctly');
@@ -740,11 +778,11 @@ fn test_zero_decimals() {
 
     let stream_id = payment_stream
         .create_stream(
-            sender, 
-            100_u256, 
-            100_u64, 
-            200_u64, 
-            true, 
+            sender,
+            100_u256,
+            100_u64,
+            200_u64,
+            true,
             token_address,
             true // Added transferable boolean
         );
@@ -763,8 +801,12 @@ fn test_eighteen_decimals() {
 
     let stream_id = payment_stream
         .create_stream(
-            sender, 1000000000000000000_u256, // 1 token
-            100_u64, 200_u64, true, token_address,
+            sender,
+            1000000000000000000_u256, // 1 token
+            100_u64,
+            200_u64,
+            true,
+            token_address,
             true // Added transferable boolean
         );
 
@@ -780,7 +822,9 @@ fn test_nineteen_decimals_panic() {
 
     // should panic because decimals > 18
     payment_stream
-        .create_stream(sender, 10000000000000000000_u256, 100_u64, 200_u64, true, token_address, true); // Added transferable boolean
+        .create_stream(
+            sender, 10000000000000000000_u256, 100_u64, 200_u64, true, token_address, true,
+        ); // Added transferable boolean
 }
 
 #[test]
@@ -827,11 +871,13 @@ fn test_transfer_stream() {
 
     start_cheat_caller_address(payment_stream.contract_address, sender);
     let stream_id = payment_stream
-        .create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address, transferable);
-    
+        .create_stream(
+            recipient, total_amount, start_time, end_time, cancelable, token_address, transferable,
+        );
+
     let new_recipient = contract_address_const::<'new_recipient'>();
     payment_stream.transfer_stream(stream_id, new_recipient);
-    
+
     let stream = payment_stream.get_stream(stream_id);
     assert(stream.recipient == new_recipient, 'Recipient update error');
 }
@@ -848,10 +894,12 @@ fn test_set_transferability() {
 
     start_cheat_caller_address(payment_stream.contract_address, sender);
     let stream_id = payment_stream
-        .create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address, transferable);
-    
+        .create_stream(
+            recipient, total_amount, start_time, end_time, cancelable, token_address, transferable,
+        );
+
     payment_stream.set_transferability(stream_id, false);
-    
+
     let stream = payment_stream.get_stream(stream_id);
     assert(!stream.transferable, 'Transferability setting error');
 }
@@ -868,8 +916,10 @@ fn test_is_transferable() {
 
     start_cheat_caller_address(payment_stream.contract_address, sender);
     let stream_id = payment_stream
-        .create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address, transferable);
-    
+        .create_stream(
+            recipient, total_amount, start_time, end_time, cancelable, token_address, transferable,
+        );
+
     let is_transferable = payment_stream.is_transferable(stream_id);
     assert(is_transferable, 'Stream should be transferable');
 }

--- a/tests/test_payment_stream.cairo
+++ b/tests/test_payment_stream.cairo
@@ -86,9 +86,9 @@ fn test_successful_create_stream() {
     let start_time = 100_u64;
     let end_time = 200_u64;
     let cancelable = true;
-
+    let transferable = true; // Corrected spelling from tranferable to transferable
     let stream_id = payment_stream
-        .create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address);
+        .create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address, transferable);
     println!("Stream ID: {}", stream_id);
 
     // This is the first Stream Created, so it will be 0.
@@ -104,9 +104,10 @@ fn test_invalid_end_time() {
     let start_time = 100_u64;
     let end_time = 50_u64;
     let cancelable = true;
+    let transferable = true; // Added transferable boolean
 
     payment_stream
-        .create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address);
+        .create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address, transferable);
 }
 
 #[test]
@@ -118,9 +119,10 @@ fn test_zero_recipient_address() {
     let start_time = 100_u64;
     let end_time = 200_u64;
     let cancelable = true;
+    let transferable = true; // Added transferable boolean
 
     payment_stream
-        .create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address);
+        .create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address, transferable);
 }
 
 #[test]
@@ -132,6 +134,7 @@ fn test_zero_token_address() {
     let start_time = 100_u64;
     let end_time = 200_u64;
     let cancelable = true;
+    let transferable = true; // Added transferable boolean
 
     payment_stream
         .create_stream(
@@ -141,6 +144,7 @@ fn test_zero_token_address() {
             end_time,
             cancelable,
             contract_address_const::<0x0>(),
+            transferable, 
         );
 }
 
@@ -153,9 +157,10 @@ fn test_zero_total_amount() {
     let start_time = 100_u64;
     let end_time = 200_u64;
     let cancelable = true;
+    let transferable = true; 
 
     payment_stream
-        .create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address);
+        .create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address, transferable);
 }
 
 #[test]
@@ -166,9 +171,10 @@ fn test_successful_create_stream_and_return_correct_rate_per_second() {
     let start_time = 0_u64;
     let end_time = 10_u64;
     let cancelable = false;
+    let transferable = true; 
 
     let stream_id = payment_stream
-        .create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address);
+        .create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address, transferable);
     let stream = payment_stream.get_stream(stream_id);
     let rate_per_second: UFixedPoint123x128 = 10_u256.into();
     assert!(stream.rate_per_second == rate_per_second, "Stream rate per second is invalid");
@@ -182,9 +188,10 @@ fn test_successful_create_stream_and_return_wrong_rate_per_second() {
     let start_time = 0_u64;
     let end_time = 10_u64;
     let cancelable = false;
+    let transferable = true; 
 
     let stream_id = payment_stream
-        .create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address);
+        .create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address, transferable);
     let stream = payment_stream.get_stream(stream_id);
     let rate_per_second: UFixedPoint123x128 = 1_u256.into();
     assert!(stream.rate_per_second == rate_per_second, "Stream rate per second is invalid");
@@ -199,9 +206,10 @@ fn test_update_stream_with_zero_rate_per_second() {
     let start_time = 0_u64;
     let end_time = 10_u64;
     let cancelable = false;
+    let transferable = true; 
 
     let stream_id = payment_stream
-        .create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address);
+        .create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address, transferable);
     let rate_per_second: UFixedPoint123x128 = 0_u256.into();
     payment_stream.update_stream_rate(stream_id, rate_per_second);
     stop_cheat_caller_address(payment_stream.contract_address);
@@ -217,14 +225,14 @@ fn test_only_creator_can_update_stream() {
     let start_time = 0_u64;
     let end_time = 10_u64;
     let cancelable = false;
+    let transferable = true; 
 
     let stream_id = payment_stream
-        .create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address);
+        .create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address, transferable);
     payment_stream.delegate_stream(stream_id, contract_address_const::<0x1>());
     stop_cheat_caller_address(payment_stream.contract_address);
     let rate_per_second: UFixedPoint123x128 = 1_u256.into();
 
-    // Unauthorized account to update stream.
     start_cheat_caller_address(payment_stream.contract_address, unauthorized);
     payment_stream.update_stream_rate(stream_id, rate_per_second);
     stop_cheat_caller_address(payment_stream.contract_address);
@@ -271,8 +279,7 @@ fn test_withdraw() {
 
     start_cheat_caller_address(payment_stream.contract_address, sender);
     let stream_id = payment_stream
-        .create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address);
-    // Sender assigns a delegate.
+        .create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address, true); 
     payment_stream.delegate_stream(stream_id, delegate);
     stop_cheat_caller_address(payment_stream.contract_address);
 
@@ -280,7 +287,6 @@ fn test_withdraw() {
     let sender_initial_balance = token_dispatcher.balance_of(sender);
     println!("Initial balance of sender: {}", sender_initial_balance);
 
-    // Simulate delegate's approval:
     start_cheat_caller_address(token_address, delegate);
     token_dispatcher.approve(payment_stream.contract_address, total_amount);
     stop_cheat_caller_address(token_address);
@@ -321,7 +327,7 @@ fn test_successful_stream_cancellation() {
     stop_cheat_caller_address(payment_stream.contract_address);
 
     let stream_id = payment_stream
-        .create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address);
+        .create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address, true); 
     println!("Stream ID: {}", stream_id);
 
     // This is the first Stream Created, so it will be 0.
@@ -350,8 +356,7 @@ fn test_withdraw_by_delegate() {
     // Sender creates a stream.
     start_cheat_caller_address(payment_stream.contract_address, sender);
     let stream_id = payment_stream
-        .create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address);
-    // Sender assigns a delegate.
+        .create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address, true); 
     payment_stream.delegate_stream(stream_id, delegate);
     stop_cheat_caller_address(payment_stream.contract_address);
 
@@ -390,7 +395,7 @@ fn test_withdraw_by_unauthorized() {
     // Sender creates a stream.
     start_cheat_caller_address(payment_stream.contract_address, sender);
     let stream_id = payment_stream
-        .create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address);
+        .create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address, true); // Added transferable boolean
     stop_cheat_caller_address(payment_stream.contract_address);
 
     // Unauthorized account attempts withdrawal.
@@ -413,7 +418,7 @@ fn test_unauthorized_cancel() {
     // Create a stream as the sender - this will automatically assign STREAM_ADMIN_ROLE
     start_cheat_caller_address(payment_stream.contract_address, sender);
     let stream_id = payment_stream
-        .create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address);
+        .create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address, true); // Added transferable boolean
 
     // Verify that the sender has the STREAM_ADMIN_ROLE after creating the stream
     let has_role = access_control.has_role(STREAM_ADMIN_ROLE, sender);
@@ -444,7 +449,7 @@ fn test_pause_stream() {
     // Create a stream
     start_cheat_caller_address(payment_stream.contract_address, sender);
     let stream_id = payment_stream
-        .create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address);
+        .create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address, true); // Added transferable boolean
 
     // Pause the stream
     payment_stream.pause(stream_id);
@@ -467,7 +472,7 @@ fn test_restart_stream() {
     // Create a stream
     start_cheat_caller_address(payment_stream.contract_address, sender);
     let stream_id = payment_stream
-        .create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address);
+        .create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address, true); // Added transferable boolean
 
     // Pause the stream first
     payment_stream.pause(stream_id);
@@ -499,7 +504,7 @@ fn test_void_stream() {
     // Create a stream
     start_cheat_caller_address(payment_stream.contract_address, sender);
     let stream_id = payment_stream
-        .create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address);
+        .create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address, true); // Added transferable boolean
 
     // Void the stream
     payment_stream.void(stream_id);
@@ -524,7 +529,7 @@ fn test_delegate_assignment_and_verification() {
     // Create stream
     start_cheat_caller_address(payment_stream.contract_address, sender);
     let stream_id = payment_stream
-        .create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address);
+        .create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address, true); // Added transferable boolean
 
     // Assign delegate
     let delegation_success = payment_stream.delegate_stream(stream_id, delegate);
@@ -551,7 +556,7 @@ fn test_multiple_delegations() {
     // Create stream
     start_cheat_caller_address(payment_stream.contract_address, sender);
     let stream_id = payment_stream
-        .create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address);
+        .create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address, true); // Added transferable boolean
 
     // Assign first delegate
     payment_stream.delegate_stream(stream_id, delegate1);
@@ -579,7 +584,7 @@ fn test_delegation_revocation() {
     // Create stream and assign delegate
     start_cheat_caller_address(payment_stream.contract_address, sender);
     let stream_id = payment_stream
-        .create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address);
+        .create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address, true); // Added transferable boolean
     payment_stream.delegate_stream(stream_id, delegate);
 
     // Verify delegate is assigned
@@ -612,7 +617,7 @@ fn test_unauthorized_delegation() {
     // Create stream as sender
     start_cheat_caller_address(payment_stream.contract_address, sender);
     let stream_id = payment_stream
-        .create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address);
+        .create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address, true); // Added transferable boolean
     stop_cheat_caller_address(payment_stream.contract_address);
 
     // Try to delegate from unauthorized address
@@ -635,7 +640,7 @@ fn test_revoke_nonexistent_delegation() {
     // Create stream
     start_cheat_caller_address(payment_stream.contract_address, sender);
     let stream_id = payment_stream
-        .create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address);
+        .create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address, true); // Added transferable boolean
 
     // Try to revoke non-existent delegation
     payment_stream.revoke_delegation(stream_id);
@@ -664,7 +669,7 @@ fn test_delegate_withdrawal_after_revocation() {
 
     start_cheat_caller_address(payment_stream.contract_address, sender);
     let stream_id = payment_stream
-        .create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address);
+        .create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address, true); // Added transferable boolean
 
     // Assign and then revoke delegate
     payment_stream.delegate_stream(stream_id, delegate);
@@ -698,7 +703,7 @@ fn test_delegate_to_zero_address() {
     // Create stream
     start_cheat_caller_address(payment_stream.contract_address, sender);
     let stream_id = payment_stream
-        .create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address);
+        .create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address, true); // Added transferable boolean
 
     // Try to delegate to zero address
     payment_stream.delegate_stream(stream_id, contract_address_const::<0x0>());
@@ -712,12 +717,13 @@ fn test_six_decimals_store() {
 
     let stream_id = payment_stream
         .create_stream(
-            sender, // recipient
-            1000000_u256, // amount (1 token in 6 decimals)
-            100_u64, // start_time
-            200_u64, // end_time
-            true, // cancelable
-            token_address // token with 6 decimals
+            sender, 
+            1000000_u256, 
+            100_u64, 
+            200_u64, 
+            true, 
+            token_address, 
+            true 
         );
 
     let stored_decimals = payment_stream.get_token_decimals(stream_id);
@@ -734,12 +740,13 @@ fn test_zero_decimals() {
 
     let stream_id = payment_stream
         .create_stream(
-            sender, // recipient
-            100_u256, // 100 tokens (0 decimals)
-            100_u64, // start_time
-            200_u64, // end_time
-            true, // cancelable
+            sender, 
+            100_u256, 
+            100_u64, 
+            200_u64, 
+            true, 
             token_address,
+            true // Added transferable boolean
         );
 
     let stored_decimals = payment_stream.get_token_decimals(stream_id);
@@ -758,6 +765,7 @@ fn test_eighteen_decimals() {
         .create_stream(
             sender, 1000000000000000000_u256, // 1 token
             100_u64, 200_u64, true, token_address,
+            true // Added transferable boolean
         );
 
     let stored_decimals = payment_stream.get_token_decimals(stream_id);
@@ -772,7 +780,7 @@ fn test_nineteen_decimals_panic() {
 
     // should panic because decimals > 18
     payment_stream
-        .create_stream(sender, 10000000000000000000_u256, 100_u64, 200_u64, true, token_address);
+        .create_stream(sender, 10000000000000000000_u256, 100_u64, 200_u64, true, token_address, true); // Added transferable boolean
 }
 
 #[test]
@@ -786,7 +794,8 @@ fn test_decimal_boundary_conditions() {
             100_u64, // start_time
             200_u64, // end_time
             true, // cancelable
-            token18 // token address
+            token18, // token address
+            true // Added transferable boolean
         );
     assert(ps18.get_token_decimals(stream_id18) == 18, 'Max decimals failed');
 
@@ -799,7 +808,68 @@ fn test_decimal_boundary_conditions() {
             100_u64, // start_time
             200_u64, // end_time
             true, // cancelable
-            token0 // token address
+            token0, // token address
+            true // Added transferable boolean
         );
     assert(ps0.get_token_decimals(stream_id0) == 0, 'Min decimals failed');
+}
+
+// New tests for the added functions
+#[test]
+fn test_transfer_stream() {
+    let (token_address, sender, payment_stream) = setup();
+    let recipient = contract_address_const::<'recipient'>();
+    let total_amount = 10000_u256;
+    let start_time = 100_u64;
+    let end_time = 200_u64;
+    let cancelable = true;
+    let transferable = true;
+
+    start_cheat_caller_address(payment_stream.contract_address, sender);
+    let stream_id = payment_stream
+        .create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address, transferable);
+    
+    let new_recipient = contract_address_const::<'new_recipient'>();
+    payment_stream.transfer_stream(stream_id, new_recipient);
+    
+    let stream = payment_stream.get_stream(stream_id);
+    assert(stream.recipient == new_recipient, 'Recipient update error');
+}
+
+#[test]
+fn test_set_transferability() {
+    let (token_address, sender, payment_stream) = setup();
+    let recipient = contract_address_const::<'recipient'>();
+    let total_amount = 10000_u256;
+    let start_time = 100_u64;
+    let end_time = 200_u64;
+    let cancelable = true;
+    let transferable = true;
+
+    start_cheat_caller_address(payment_stream.contract_address, sender);
+    let stream_id = payment_stream
+        .create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address, transferable);
+    
+    payment_stream.set_transferability(stream_id, false);
+    
+    let stream = payment_stream.get_stream(stream_id);
+    assert(!stream.transferable, 'Transferability setting error');
+}
+
+#[test]
+fn test_is_transferable() {
+    let (token_address, sender, payment_stream) = setup();
+    let recipient = contract_address_const::<'recipient'>();
+    let total_amount = 10000_u256;
+    let start_time = 100_u64;
+    let end_time = 200_u64;
+    let cancelable = true;
+    let transferable = true;
+
+    start_cheat_caller_address(payment_stream.contract_address, sender);
+    let stream_id = payment_stream
+        .create_stream(recipient, total_amount, start_time, end_time, cancelable, token_address, transferable);
+    
+    let is_transferable = payment_stream.is_transferable(stream_id);
+    assert(is_transferable, 'Stream should be transferable');
 }


### PR DESCRIPTION
- Modified the Stream struct to include a transferable: bool field
- Updated the create_stream function to accept a transferable parameter
- The function stores the transferability flag in the Stream struct
- Applied transfer restrictions in the NFT implementation
- Emitted appropriate events to indicate transferability
- Stream creator can specify whether a stream is transferable
- Non-transferable streams cannot be transferred to other addresses
- Transferable streams can be traded and change ownership
- All functions respect the new ownership after transfers
- Closes issue #58 