### PR TITLE
Feat: Implement Campaign Donation Withdraw Function

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-scarb 2.11.4
-starknet-foundry 0.39.0
+scarb 2.11.2
+starknet-foundry 0.40.0

--- a/src/campaign_donation.cairo
+++ b/src/campaign_donation.cairo
@@ -13,7 +13,7 @@ pub mod CampaignDonation {
         StoragePointerReadAccess, StoragePointerWriteAccess,
     };
     use starknet::{
-        ClassHash, ContractAddress, get_block_timestamp, get_caller_address, get_contract_address,
+        ClassHash, ContractAddress, get_block_timestamp, get_caller_address, get_contract_address, contract_address_const
     };
     use crate::base::errors::Errors::{CAMPAIGN_REF_EMPTY, CAMPAIGN_REF_EXISTS, ZERO_AMOUNT};
     use crate::base::types::{Campaigns, Donations};
@@ -47,7 +47,9 @@ pub mod CampaignDonation {
         //     (ContractAddress, u256), CampaignWithdrawal,
         // >, // map<(campaign_owner, campaign_id), CampaignWithdrawal>
         // Track existing campaign refs
-        campaign_refs: Map<felt252, bool> // All campaign ref to use for is_campaign_ref_exists
+        campaign_refs: Map<felt252, bool>, // All campaign ref to use for is_campaign_ref_exists
+        campaign_closed: Map<u256, bool>, // Map campaign ids to closing boolean
+        campaign_withdrawn: Map<u256, bool>, //Map campaign ids to whether they have been withdrawn
     }
 
 
@@ -204,7 +206,40 @@ pub mod CampaignDonation {
         }
 
 
-        fn withdraw_from_campaign(ref self: ContractState, campaign_id: u256) {}
+        fn withdraw_from_campaign(ref self: ContractState, campaign_id: u256) {
+            let caller = get_caller_address();
+            let mut campaign = self.campaigns.read(campaign_id);
+            let campaign_owner = campaign.owner;
+            assert(caller == campaign_owner, 'Caller is Not Campaign Owner');
+            assert(campaign.current_amount >= campaign.target_amount, 'Target Not Reached');
+            campaign.is_goal_reached = true;
+            self.campaign_closed.write(campaign_id, true);
+
+            let this_contract = get_contract_address();
+
+            assert(campaign.is_closed, 'Campaign Not Closed');
+
+            assert(self.campaign_withdrawn.read(campaign_id), 'Double Withdrawal');
+
+            // Hard code usdc
+            let usdc_address = contract_address_const::<0x053c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8>();
+
+            let token = IERC20Dispatcher { contract_address: usdc_address };
+
+            let approve = token.approve(campaign_owner, campaign.target_amount);
+
+            assert(approve, 'Approval failed');
+
+            let allowance = token.allowance(this_contract, campaign_owner);
+
+            assert(!allowance.is_zero(), 'Zero allowance found');
+
+            let transfer_from = token.transfer_from(this_contract, campaign_owner, allowance);
+
+            assert(transfer_from, 'Withdraw failed');
+
+
+        }
 
         fn get_donation(self: @ContractState, campaign_id: u256, donation_id: u256) -> Donations {
             let donations: Donations = self.donations.entry(campaign_id).entry(donation_id).read();

--- a/src/campaign_donation.cairo
+++ b/src/campaign_donation.cairo
@@ -13,7 +13,7 @@ pub mod CampaignDonation {
         StoragePointerReadAccess, StoragePointerWriteAccess,
     };
     use starknet::{
-        ClassHash, ContractAddress, contract_address_const, get_block_timestamp, get_caller_address,
+        ClassHash, ContractAddress, contract_address_const ,get_block_timestamp, get_caller_address,
         get_contract_address,
     };
     use crate::base::errors::Errors::{CAMPAIGN_REF_EMPTY, CAMPAIGN_REF_EXISTS, ZERO_AMOUNT};
@@ -220,7 +220,7 @@ pub mod CampaignDonation {
 
             assert(campaign.is_closed, 'Campaign Not Closed');
 
-            assert(self.campaign_withdrawn.read(campaign_id), 'Double Withdrawal');
+            assert(!self.campaign_withdrawn.read(campaign_id), 'Double Withdrawal');
 
             let asset = campaign.asset;
             let asset_address = self.get_asset_address(asset);

--- a/src/campaign_donation.cairo
+++ b/src/campaign_donation.cairo
@@ -13,7 +13,8 @@ pub mod CampaignDonation {
         StoragePointerReadAccess, StoragePointerWriteAccess,
     };
     use starknet::{
-        ClassHash, ContractAddress, get_block_timestamp, get_caller_address, get_contract_address, contract_address_const
+        ClassHash, ContractAddress, contract_address_const, get_block_timestamp, get_caller_address,
+        get_contract_address,
     };
     use crate::base::errors::Errors::{CAMPAIGN_REF_EMPTY, CAMPAIGN_REF_EXISTS, ZERO_AMOUNT};
     use crate::base::types::{Campaigns, Donations};
@@ -49,7 +50,7 @@ pub mod CampaignDonation {
         // Track existing campaign refs
         campaign_refs: Map<felt252, bool>, // All campaign ref to use for is_campaign_ref_exists
         campaign_closed: Map<u256, bool>, // Map campaign ids to closing boolean
-        campaign_withdrawn: Map<u256, bool>, //Map campaign ids to whether they have been withdrawn
+        campaign_withdrawn: Map<u256, bool> //Map campaign ids to whether they have been withdrawn
     }
 
 
@@ -221,10 +222,10 @@ pub mod CampaignDonation {
 
             assert(self.campaign_withdrawn.read(campaign_id), 'Double Withdrawal');
 
-            // Hard code usdc
-            let usdc_address = contract_address_const::<0x053c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8>();
+            let asset = campaign.asset;
+            let asset_address = self.get_asset_address(asset);
 
-            let token = IERC20Dispatcher { contract_address: usdc_address };
+            let token = IERC20Dispatcher { contract_address: asset_address };
 
             let approve = token.approve(campaign_owner, campaign.target_amount);
 
@@ -234,11 +235,12 @@ pub mod CampaignDonation {
 
             assert(!allowance.is_zero(), 'Zero allowance found');
 
-            let transfer_from = token.transfer_from(this_contract, campaign_owner, allowance);
+            assert(allowance >= campaign.target_amount, 'Insufficient allowance');
+
+            let transfer_from = token
+                .transfer_from(this_contract, campaign_owner, campaign.target_amount);
 
             assert(transfer_from, 'Withdraw failed');
-
-
         }
 
         fn get_donation(self: @ContractState, campaign_id: u256, donation_id: u256) -> Donations {
@@ -299,6 +301,39 @@ pub mod CampaignDonation {
         fn get_campaign(self: @ContractState, camapign_id: u256) -> Campaigns {
             let campaign: Campaigns = self.campaigns.read(camapign_id);
             campaign
+        }
+    }
+
+    #[generate_trait]
+    impl InternalImpl of InternalTrait {
+        fn get_asset_address(self: @ContractState, token_name: felt252) -> ContractAddress {
+            let mut token_address: ContractAddress = contract_address_const::<0>();
+            if token_name == 'USDC' || token_name == 'usdt' {
+                token_address =
+                    contract_address_const::<
+                        0x053c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8,
+                    >();
+            }
+            if token_name == 'STRK' || token_name == 'strk' {
+                token_address =
+                    contract_address_const::<
+                        0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d,
+                    >()
+            }
+            if token_name == 'ETH' || token_name == 'eth' {
+                token_address =
+                    contract_address_const::<
+                        0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7,
+                    >();
+            }
+            if token_name == 'USDT' || token_name == 'usdt' {
+                token_address =
+                    contract_address_const::<
+                        0x068f5c6a61780768455de69077e07e89787839bf8166decfbf92b645209c0fb8,
+                    >()
+            }
+
+            token_address
         }
     }
 }

--- a/tests/test_campaign_donation.cairo
+++ b/tests/test_campaign_donation.cairo
@@ -449,3 +449,61 @@ fn test_multiple_campaigns_with_donations() {
     let campaigns = campaign_donation.get_campaigns();
     assert(campaigns.len() == 2, 'Should return 2 campaigns');
 }
+
+#[test]
+#[fork(
+    url: "https://starknet-sepolia.public.blastapi.io/rpc/v0_7",
+    block_tag: latest
+)]
+fn test_withdraw_funds_from_campaign_successful() {
+    let (token_address, sender, campaign_donation, _erc721) = setup();
+    let target_amount = 500_u256;
+    let asset = 'Test';
+    let campaign_ref = 'Test';
+    let owner = contract_address_const::<'owner'>();
+
+    start_cheat_caller_address(campaign_donation.contract_address, owner);
+    let campaign_id = campaign_donation.create_campaign(campaign_ref, target_amount, asset);
+
+    let token_dispatcher = IERC20Dispatcher { contract_address: token_address };
+    stop_cheat_caller_address(campaign_donation.contract_address);
+    // This is the first Campaign Created, so it will be 1.
+    assert!(campaign_id == 1_u256, "Campaign creation failed");
+
+    let donor = contract_address_const::<'donor'>();
+
+    let user_balance_before = token_dispatcher.balance_of(sender);
+    let contract_balance_before = token_dispatcher.balance_of(campaign_donation.contract_address);
+
+    // Simulate delegate's approval:
+    start_cheat_caller_address(token_address, sender);
+    token_dispatcher.approve(campaign_donation.contract_address, 1000);
+    stop_cheat_caller_address(token_address);
+
+    let allowance = token_dispatcher.allowance(sender, campaign_donation.contract_address);
+    assert(allowance >= 1000, 'Allowance not set correctly');
+    println!("Allowance for withdrawal: {}", allowance);
+
+    start_cheat_caller_address(campaign_donation.contract_address, sender);
+
+    let donation_id = campaign_donation.donate_to_campaign(campaign_id, 600, token_address);
+
+    stop_cheat_caller_address(campaign_donation.contract_address);
+
+    // let donation = campaign_donation.get_donation(campaign_id, donation_id);
+
+    start_cheat_caller_address(campaign_donation.contract_address, owner);
+
+    let owner_balance_before = token_dispatcher.balance_of(owner);
+    let contract_balance_before = token_dispatcher.balance_of(campaign_donation.contract_address);
+
+    campaign_donation.withdraw_from_campaign(campaign_id);
+
+    let owner_balance_after = token_dispatcher.balance_of(owner);
+    let contract_balance_after = token_dispatcher.balance_of(campaign_donation.contract_address);
+
+    stop_cheat_caller_address(campaign_donation.contract_address);
+
+    assert(owner_balance_after - owner_balance_before == 500, 'Withdrawal error')
+
+}

--- a/tests/test_campaign_donation.cairo
+++ b/tests/test_campaign_donation.cairo
@@ -451,10 +451,7 @@ fn test_multiple_campaigns_with_donations() {
 }
 
 #[test]
-#[fork(
-    url: "https://starknet-sepolia.public.blastapi.io/rpc/v0_7",
-    block_tag: latest
-)]
+#[fork(url: "https://starknet-sepolia.public.blastapi.io/rpc/v0_7", block_tag: latest)]
 fn test_withdraw_funds_from_campaign_successful() {
     let (token_address, sender, campaign_donation, _erc721) = setup();
     let target_amount = 500_u256;
@@ -505,5 +502,4 @@ fn test_withdraw_funds_from_campaign_successful() {
     stop_cheat_caller_address(campaign_donation.contract_address);
 
     assert(owner_balance_after - owner_balance_before == 500, 'Withdrawal error')
-
 }


### PR DESCRIPTION
## Changes Made:

- Implemented thr withdraw_from_campaign function as stated in the interfaces
- Did fork testing to sepolia, since usdc address is hardcoded in the function.

This PR successfully builds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enabled campaign owners to withdraw funds from a campaign once the target amount is reached, with safeguards to prevent double withdrawals.
- **Bug Fixes**
  - Improved enforcement of campaign closure and withdrawal status to ensure correct fund management.
- **Tests**
  - Added a test to verify successful withdrawal of campaign funds and correct token transfers to the campaign owner.
- **Chores**
  - Updated tool versions for improved compatibility and stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->